### PR TITLE
Replaced "burnbright/silverstripe-shop" dependency with "silvershop/core"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	},
 	"require": {
 		"silverstripe/framework": "~3.1",
-		"burnbright/silverstripe-shop": "*",
+		"silvershop/core": "~1.0",
 		"bummzack/sortablefile": "*"
 	}
 }


### PR DESCRIPTION
As stated at https://packagist.org/packages/burnbright/silverstripe-shop, 

> This package is abandoned and no longer maintained. The author suggests using the silvershop/core package instead.

Currently when you install `silvershop/core` and then install install this module, you end up with a `shop` folder in your root (from `silvershop/core`) and a `silvershop` folder in your root (from `burnbright/silverstripe-shop`). This of course causes errors that prevent the website from working at all.
