### PR TITLE
Set SilverShop Core dependency for compatibility with both v1.x and v2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	},
 	"require": {
 		"silverstripe/framework": "~3.1",
-		"silvershop/core": "~1.0",
+    "silvershop/core": "~1.0 || ~2.0",
 		"bummzack/sortablefile": "*"
 	}
 }


### PR DESCRIPTION
Updated the dependency requirements to allow for SilverShop v2.0
